### PR TITLE
feat(security): implement role-based access control (RBAC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/tdevilleduc/urthehero/compare/0.3.0...HEAD
 
+### Added
+
+- Implement role-based access control (RBAC): add `role` field to `User` entity, enable `@EnableMethodSecurity`, restrict all write operations (PUT/POST/DELETE) to `ROLE_ADMIN` across Enemy, Page, Story and Person controllers
+
 ### Changed
 
 - Replace deprecated OpenJDK 11 images with Eclipse Temurin 21 in `.gitlab-ci.yml`, `back/Dockerfile` and `docker-compose.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 ### Fixed
 
 - Remove incorrect `test` scope from `commons-lang3` dependency (used at runtime by springdoc)
+- Add `role` field to `UserDTO` (default `ROLE_USER`) to prevent ModelMapper from nullifying the `User` entity's role on creation
+- Make `User#getRole()` open to allow Hibernate proxy generation
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A **choose-your-own-adventure** REST API backend. Players navigate through stori
 
 - **Language**: Kotlin
 - **Framework**: Spring Boot 4.0.5 / Spring Cloud 2025.1.1
-- **Security**: Spring Security 7 + JWT
+- **Security**: Spring Security 7 + JWT + RBAC (`ROLE_ADMIN` / `ROLE_USER`)
 - **Database**: PostgreSQL
 - **API docs**: SpringDoc / OpenAPI (Swagger UI)
 - **Resilience**: Resilience4j (circuit breaker, retry)
@@ -92,6 +92,15 @@ POST /authenticate
 ```
 
 Use the returned token as a `Bearer` header or via the Swagger UI lock icon.
+
+### Authorization
+
+Two roles are supported:
+
+| Role         | Permissions                                      |
+|--------------|--------------------------------------------------|
+| `ROLE_ADMIN` | Full access — read and write (PUT/POST/DELETE)   |
+| `ROLE_USER`  | Read-only access                                 |
 
 ### Available endpoints
 

--- a/back/pom.xml
+++ b/back/pom.xml
@@ -52,6 +52,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/config/SecurityConfig.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/config/SecurityConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -19,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig(
     @Lazy private val myUserDetailsService: MyUserDetailsService,
     private val jwtRequestFilter: JwtRequestFilter

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/controller/EnemyController.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/controller/EnemyController.kt
@@ -8,6 +8,7 @@ import com.tdevilleduc.urthehero.back.service.IEnemyService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
 import org.slf4j.helpers.MessageFormatter
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -37,6 +38,7 @@ internal class EnemyController(private val enemyService: IEnemyService) {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
 //    @Operation(summary = "\${swagger.controller.enemy.create.value}", description = "\${swagger.controller.enemy.create.notes}")
     fun create(@RequestBody enemyDto: EnemyDTO): Callable<ResponseEntity<EnemyDTO>> = Callable {
         if (enemyService.exists(enemyDto.id)) {
@@ -46,6 +48,7 @@ internal class EnemyController(private val enemyService: IEnemyService) {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
 //    @Operation(summary = "\${swagger.controller.enemy.update.value}", description = "\${swagger.controller.enemy.update.notes}")
     fun update(@RequestBody enemyDto: EnemyDTO): Callable<ResponseEntity<EnemyDTO>> = Callable {
         Assert.notNull(enemyDto.id) { throw EnemyInternalErrorException(ApplicationConstants.ERROR_MESSAGE_ENEMY_ID_CANNOT_BE_NULL) }
@@ -56,6 +59,7 @@ internal class EnemyController(private val enemyService: IEnemyService) {
     }
 
     @DeleteMapping(value = ["/{enemyId}"])
+    @PreAuthorize("hasRole('ADMIN')")
 //    @Operation(summary = "\${swagger.controller.enemy.delete.value}", description = "\${swagger.controller.enemy.delete.notes}")
     fun delete(@PathVariable enemyId: Int) = Callable {
         enemyService.delete(enemyId)

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/controller/PageController.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/controller/PageController.kt
@@ -9,6 +9,7 @@ import com.tdevilleduc.urthehero.back.service.IStoryService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
 import org.slf4j.helpers.MessageFormatter
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -42,6 +43,7 @@ internal class PageController(private val storyService: IStoryService, private v
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun createPage(@RequestBody page: PageDTO): Callable<ResponseEntity<PageDTO>> = Callable {
         if (pageService.exists(page.id)) {
@@ -51,6 +53,7 @@ internal class PageController(private val storyService: IStoryService, private v
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun updatePage(@RequestBody pageDto: PageDTO): Callable<ResponseEntity<PageDTO>> = Callable {
         Assert.notNull(pageDto.id) { throw PageInternalErrorException(ApplicationConstants.ERROR_MESSAGE_PAGE_PAGEID_CANNOT_BE_NULL) }
@@ -61,6 +64,7 @@ internal class PageController(private val storyService: IStoryService, private v
     }
 
     @DeleteMapping(value = ["/{pageId}"])
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun deletePage(@PathVariable pageId: Int) = Callable {
         pageService.delete(pageId)

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/controller/PersonController.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/controller/PersonController.kt
@@ -8,6 +8,7 @@ import com.tdevilleduc.urthehero.back.service.IUserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
 import org.slf4j.helpers.MessageFormatter
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -39,6 +40,7 @@ internal class PersonController(private val userService: IUserService) {
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun createUser(@RequestBody userDto: UserDTO): Callable<ResponseEntity<UserDTO>> = Callable {
         if (userService.exists(userDto.userId)) {
@@ -48,6 +50,7 @@ internal class PersonController(private val userService: IUserService) {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun updateUser(@RequestBody userDto: UserDTO): Callable<ResponseEntity<UserDTO>> = Callable {
         Assert.notNull(userDto.userId) { throw UserInternalErrorException(ApplicationConstants.ERROR_MESSAGE_USER_USERID_CANNOT_BE_NULL) }
@@ -58,6 +61,7 @@ internal class PersonController(private val userService: IUserService) {
     }
 
     @DeleteMapping(value = ["/{userId}"])
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun deleteUser(@PathVariable userId: Int) = Callable {
         userService.delete(userId)

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/controller/StoryController.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/controller/StoryController.kt
@@ -10,6 +10,7 @@ import com.tdevilleduc.urthehero.back.service.IUserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.access.prepost.PreAuthorize
 import org.slf4j.helpers.MessageFormatter
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -41,6 +42,7 @@ internal class StoryController(private val storyService: IStoryService, private 
     }
 
     @PutMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun createStory(@RequestBody storyDTO: StoryDTO): Callable<ResponseEntity<StoryDTO>> = Callable {
         Assert.notNull(storyDTO.authorId) { throw StoryInternalErrorException("L'auteur de l'histoire passée en paramètre ne peut pas être null") }
@@ -58,6 +60,7 @@ internal class StoryController(private val storyService: IStoryService, private 
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun updateStory(@RequestBody storyDto: StoryDTO): Callable<ResponseEntity<StoryDTO>> = Callable {
         Assert.notNull(storyDto.authorId) { throw StoryInternalErrorException("L'auteur de l'histoire passée en paramètre ne peut pas être null") }
@@ -76,6 +79,7 @@ internal class StoryController(private val storyService: IStoryService, private 
     }
 
     @DeleteMapping(value = ["/{storyId}"])
+    @PreAuthorize("hasRole('ADMIN')")
     @ResponseBody
     fun deleteStory(@PathVariable storyId: Int) = Callable {
         storyService.delete(storyId)

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/model/User.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/model/User.kt
@@ -49,7 +49,7 @@ open class User (
         return password
     }
 
-    fun getRole(): String {
+    open fun getRole(): String {
         return role
     }
 

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/model/User.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/model/User.kt
@@ -2,6 +2,7 @@ package com.tdevilleduc.urthehero.back.model
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 import java.io.Serializable
 import jakarta.persistence.*
@@ -15,7 +16,9 @@ open class User (
         @Schema(description = "\${swagger.model.user.param.storyId}")
         open var userId: Int?,
         private var username: String = "",
-        private var password: String = ""
+        private var password: String = "",
+        @Column(nullable = false)
+        private var role: String = "ROLE_USER"
 ) : Serializable, UserDetails {
 
     override fun isAccountNonExpired(): Boolean {
@@ -35,7 +38,7 @@ open class User (
     }
 
     override fun getAuthorities(): Collection<GrantedAuthority> {
-        return emptyList()
+        return listOf(SimpleGrantedAuthority(role))
     }
 
     override fun getUsername(): String {
@@ -46,11 +49,19 @@ open class User (
         return password
     }
 
+    fun getRole(): String {
+        return role
+    }
+
     open fun setUsername(username: String) {
         this.username = username
     }
 
     open fun setPassword(password: String) {
         this.password = password
+    }
+
+    open fun setRole(role: String) {
+        this.role = role
     }
 }

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/model/UserDTO.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/model/UserDTO.kt
@@ -4,5 +4,6 @@ package com.tdevilleduc.urthehero.back.model
 class UserDTO (
         var userId: Int? = null,
         var username: String = "",
-        var password: String = ""
+        var password: String = "",
+        var role: String = "ROLE_USER"
 )

--- a/back/src/main/java/com/tdevilleduc/urthehero/back/service/impl/MyUserDetailsService.kt
+++ b/back/src/main/java/com/tdevilleduc/urthehero/back/service/impl/MyUserDetailsService.kt
@@ -13,7 +13,6 @@ class MyUserDetailsService : UserDetailsService {
     private lateinit var userService: IUserService
 
     override fun loadUserByUsername(userName: String): User {
-        val user = userService.findByUsername(userName)
-        return User(null, username = user.username, password = user.password)
+        return userService.findByUsername(userName)
     }
 }

--- a/back/src/main/resources/data.sql
+++ b/back/src/main/resources/data.sql
@@ -3,9 +3,9 @@
 --INSERT INTO person(display_name, email, login, password) VALUES('Marion Gianesini', 'marion@gmail.com', 'mgianesini', 'password');
 --INSERT INTO person(display_name, email, login, password) VALUES('Nicolas Danet', 'nicolas@gmail.com', 'ndanet', 'password');
 -- USERS -- userId, displayName, login, email
-INSERT INTO users(username, password) VALUES('tdevilleduc', '$2a$10$Pa1dGSZT420g4.W6f3v7L.7hFlpuOBeXpmScnFh8JZEL3a5ZKNZ2K');
-INSERT INTO users(username, password) VALUES('mgianesini', '$2a$10$Pa1dGSZT420g4.W6f3v7L.7hFlpuOBeXpmScnFh8JZEL3a5ZKNZ2K');
-INSERT INTO users(username, password) VALUES('ndanet', '$2a$10$Pa1dGSZT420g4.W6f3v7L.7hFlpuOBeXpmScnFh8JZEL3a5ZKNZ2K');
+INSERT INTO users(username, password, role) VALUES('tdevilleduc', '$2a$10$Pa1dGSZT420g4.W6f3v7L.7hFlpuOBeXpmScnFh8JZEL3a5ZKNZ2K', 'ROLE_ADMIN');
+INSERT INTO users(username, password, role) VALUES('mgianesini', '$2a$10$Pa1dGSZT420g4.W6f3v7L.7hFlpuOBeXpmScnFh8JZEL3a5ZKNZ2K', 'ROLE_USER');
+INSERT INTO users(username, password, role) VALUES('ndanet', '$2a$10$Pa1dGSZT420g4.W6f3v7L.7hFlpuOBeXpmScnFh8JZEL3a5ZKNZ2K', 'ROLE_USER');
 -- PAGE -- storyId, image, text
 INSERT INTO page(story_id, image, text) VALUES(1, 'image3', 'Ulysse');
 INSERT INTO page(story_id, image, text) VALUES(1, 'image3', 'Dès');

--- a/back/src/test/java/com/tdevilleduc/urthehero/back/controller/EnemyControllerTest.kt
+++ b/back/src/test/java/com/tdevilleduc/urthehero/back/controller/EnemyControllerTest.kt
@@ -14,11 +14,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
@@ -43,10 +46,12 @@ internal class EnemyControllerTest : AbstractITTest() {
     fun setup() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
                 .build()
     }
 
     @Test
+    @WithMockUser
     fun test_getById() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/1"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -63,6 +68,7 @@ internal class EnemyControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
     fun test_getByLevel() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/level/1"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -79,6 +85,7 @@ internal class EnemyControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_create_thenSuccess() {
         val enemyDto = TestUtil.createEnemyDto()
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.put(uriController)
@@ -92,6 +99,7 @@ internal class EnemyControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_create_thenAlreadyExists() {
         val enemyDto = TestUtil.createEnemyDto()
         enemyDto.id = 1
@@ -105,6 +113,17 @@ internal class EnemyControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
+    fun test_create_asUser_thenForbidden() {
+        val enemyDto = TestUtil.createEnemyDto()
+        mockMvc.perform(MockMvcRequestBuilders.put(uriController)
+                .content(objectMapper.writeValueAsString(enemyDto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_delete_thenSuccess() {
         var enemy = TestUtil.createEnemy()
         enemy = enemyDao.save(enemy)
@@ -120,5 +139,12 @@ internal class EnemyControllerTest : AbstractITTest() {
 
         val optionalAfter: Optional<Enemy> = enemyDao.findById(enemy.id)
         Assertions.assertTrue(optionalAfter.isEmpty)
+    }
+
+    @Test
+    @WithMockUser
+    fun test_delete_asUser_thenForbidden() {
+        mockMvc.perform(MockMvcRequestBuilders.delete("$uriController/1"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
     }
 }

--- a/back/src/test/java/com/tdevilleduc/urthehero/back/controller/PageControllerTest.kt
+++ b/back/src/test/java/com/tdevilleduc/urthehero/back/controller/PageControllerTest.kt
@@ -13,11 +13,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
@@ -42,10 +45,12 @@ internal class PageControllerTest : AbstractITTest() {
     fun setup() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
                 .build()
     }
 
     @Test
+    @WithMockUser
     fun test_getPageById() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/1"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -61,6 +66,7 @@ internal class PageControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
     fun test_getFirstPageByStoryId() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/story/2"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -75,6 +81,7 @@ internal class PageControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_createPage_thenSuccess() {
         val pageDto = TestUtil.createPageDto()
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.put(uriController)
@@ -88,6 +95,7 @@ internal class PageControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_createPage_thenAlreadyExists() {
         val pageDto = TestUtil.createPageDto()
         pageDto.id = 1
@@ -101,6 +109,17 @@ internal class PageControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
+    fun test_createPage_asUser_thenForbidden() {
+        val pageDto = TestUtil.createPageDto()
+        mockMvc.perform(MockMvcRequestBuilders.put(uriController)
+                .content(objectMapper.writeValueAsString(pageDto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_deletePage_thenSuccess() {
         var page = TestUtil.createPage()
         page = pageDao.save(page)
@@ -116,5 +135,12 @@ internal class PageControllerTest : AbstractITTest() {
 
         val optionalAfter: Optional<Page> = pageDao.findById(page.id)
         Assertions.assertTrue(optionalAfter.isEmpty)
+    }
+
+    @Test
+    @WithMockUser
+    fun test_deletePage_asUser_thenForbidden() {
+        mockMvc.perform(MockMvcRequestBuilders.delete("$uriController/1"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
     }
 }

--- a/back/src/test/java/com/tdevilleduc/urthehero/back/controller/PersonControllerTest.kt
+++ b/back/src/test/java/com/tdevilleduc/urthehero/back/controller/PersonControllerTest.kt
@@ -14,11 +14,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
@@ -43,10 +46,14 @@ internal class PersonControllerTest : AbstractITTest() {
 
     @BeforeEach
     fun setup() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build()
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
+                .build()
     }
 
     @Test
+    @WithMockUser
     fun test_getAllUsers_thenSuccess() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/all"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -59,6 +66,7 @@ internal class PersonControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
     fun test_getUserById_thenSuccess() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/2"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -72,6 +80,7 @@ internal class PersonControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_createUser_thenSuccess() {
         val userDto = TestUtil.createUserDto()
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.put(uriController)
@@ -88,6 +97,7 @@ internal class PersonControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_createUser_thenAlreadyExists() {
         val userDto = TestUtil.createUserDto()
         userDto.userId = 1
@@ -101,6 +111,17 @@ internal class PersonControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
+    fun test_createUser_asUser_thenForbidden() {
+        val userDto = TestUtil.createUserDto()
+        mockMvc.perform(MockMvcRequestBuilders.put(uriController)
+                .content(objectMapper.writeValueAsString(userDto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_deleteUser_thenSuccess() {
         var user = TestUtil.createUser()
         user = userDao.save(user)
@@ -116,5 +137,12 @@ internal class PersonControllerTest : AbstractITTest() {
 
         val optionalAfter: Optional<User> = userDao.findById(user.userId!!)
         Assertions.assertTrue(optionalAfter.isEmpty)
+    }
+
+    @Test
+    @WithMockUser
+    fun test_deleteUser_asUser_thenForbidden() {
+        mockMvc.perform(MockMvcRequestBuilders.delete("$uriController/1"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
     }
 }

--- a/back/src/test/java/com/tdevilleduc/urthehero/back/controller/StoryControllerTest.kt
+++ b/back/src/test/java/com/tdevilleduc/urthehero/back/controller/StoryControllerTest.kt
@@ -13,11 +13,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
@@ -42,10 +45,12 @@ internal class StoryControllerTest : AbstractITTest() {
     fun setup() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply<DefaultMockMvcBuilder>(springSecurity())
                 .build()
     }
 
     @Test
+    @WithMockUser
     fun test_getAllStories() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/all"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -58,6 +63,7 @@ internal class StoryControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
     fun test_getStoryById() {
         val resultActions = mockMvc.perform(MockMvcRequestBuilders.get("$uriController/2"))
                 .andExpect(MockMvcResultMatchers.request().asyncStarted())
@@ -75,6 +81,7 @@ internal class StoryControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_createStory_thenSuccess() {
         val authorId = 1
         val firstPageId = 1
@@ -90,6 +97,7 @@ internal class StoryControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_createStory_thenAlreadyExists() {
         val authorId = 1
         val firstPageId = 1
@@ -105,6 +113,17 @@ internal class StoryControllerTest : AbstractITTest() {
     }
 
     @Test
+    @WithMockUser
+    fun test_createStory_asUser_thenForbidden() {
+        val storyDto = TestUtil.createStoryDto(1, 1)
+        mockMvc.perform(MockMvcRequestBuilders.put(uriController)
+                .content(objectMapper.writeValueAsString(storyDto))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser(roles = ["ADMIN"])
     fun test_deleteStory_thenSuccess() {
         var story = TestUtil.createStory()
         story = storyDao.save(story)
@@ -122,4 +141,10 @@ internal class StoryControllerTest : AbstractITTest() {
         Assertions.assertTrue(optionalAfter.isEmpty)
     }
 
+    @Test
+    @WithMockUser
+    fun test_deleteStory_asUser_thenForbidden() {
+        mockMvc.perform(MockMvcRequestBuilders.delete("$uriController/1"))
+                .andExpect(MockMvcResultMatchers.status().isForbidden)
+    }
 }

--- a/back/src/test/java/com/tdevilleduc/urthehero/back/model/PersonTest.kt
+++ b/back/src/test/java/com/tdevilleduc/urthehero/back/model/PersonTest.kt
@@ -5,15 +5,24 @@ import org.junit.jupiter.api.Test
 import org.apache.commons.lang3.RandomStringUtils
 
 internal class PersonTest {
-//    @Test
-//    fun test_Constructor() {
-//        val personId = 31
-//        val personLogin = RandomStringUtils.random(20)
-//        val person = User(personId, personLogin)
-//        Assertions.assertEquals(person.username, personLogin)
-//        val secondPerson = User(personId)
-//        secondPerson.username = personLogin
-//        Assertions.assertEquals(secondPerson.toString(), person.toString())
-//        Assertions.assertEquals(secondPerson, person)
-//    }
+    @Test
+    fun test_defaultRole_isRoleUser() {
+        val user = User(null, "username", "password")
+        Assertions.assertEquals("ROLE_USER", user.getRole())
+    }
+
+    @Test
+    fun test_adminRole() {
+        val user = User(null, "username", "password", "ROLE_ADMIN")
+        Assertions.assertEquals("ROLE_ADMIN", user.getRole())
+        Assertions.assertEquals(1, user.authorities.size)
+        Assertions.assertEquals("ROLE_ADMIN", user.authorities.first().authority)
+    }
+
+    @Test
+    fun test_setRole() {
+        val user = User(null, "username", "password")
+        user.setRole("ROLE_ADMIN")
+        Assertions.assertEquals("ROLE_ADMIN", user.getRole())
+    }
 }

--- a/back/src/test/java/com/tdevilleduc/urthehero/back/service/PersonServiceTest.kt
+++ b/back/src/test/java/com/tdevilleduc/urthehero/back/service/PersonServiceTest.kt
@@ -51,6 +51,7 @@ internal class PersonServiceTest {
         Assertions.assertEquals(userId, user.userId)
         Assertions.assertEquals(expectedUser.username, user.username)
         Assertions.assertEquals(expectedUser.password, user.password)
+        Assertions.assertEquals(expectedUser.getRole(), user.getRole())
     }
     @Test
     fun test_findById_thenNotFound() {
@@ -78,6 +79,7 @@ internal class PersonServiceTest {
         Assertions.assertEquals(expectedUser.userId, user.userId)
         Assertions.assertEquals(expectedUser.username, user.username)
         Assertions.assertEquals(expectedUser.password, user.password)
+        Assertions.assertEquals(expectedUser.getRole(), user.getRole())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `role` field to `User` entity (`ROLE_ADMIN` / `ROLE_USER`), returned as a `GrantedAuthority`
- Enable `@EnableMethodSecurity` in `SecurityConfig` and restrict all write operations (PUT/POST/DELETE) to `ROLE_ADMIN` across Enemy, Page, Story and Person controllers
- Fix `MyUserDetailsService` to return the full `User` object (including role) instead of a stripped copy
- Update `data.sql`: assign `ROLE_ADMIN` to `tdevilleduc`, `ROLE_USER` to `mgianesini` and `ndanet`
- Document the new authorization model in README and CHANGELOG

## Test plan

- [x] `POST /authenticate` avec un utilisateur `ROLE_USER` → les appels PUT/POST/DELETE retournent `403`
- [x] `POST /authenticate` avec `tdevilleduc` (`ROLE_ADMIN`) → les appels PUT/POST/DELETE passent
- [x] `./mvnw -pl back test` passe sans erreur
